### PR TITLE
Fix wasm path handling in nested folders on Windows

### DIFF
--- a/WASMbindgenAsset.js
+++ b/WASMbindgenAsset.js
@@ -144,7 +144,7 @@ class WASMbindgenAsset extends Asset {
     let wasm_path = path.relative(path.dirname(this.name), path.join(loc, rustName + '_bg.wasm'))
     if (wasm_path[0] !== '.')
       wasm_path = './' + wasm_path
-    wasm_path = wasm_path.replace('\\', '/')
+    wasm_path = wasm_path.replace(/\\/g, '/')
 
     js_content = js_content.replace(/import\ \*\ as\ wasm.+?;/, 'var wasm;const __exports = {};')
     js_content = js_content.replace(/import.+?snippets.+?;/g, line => {


### PR DESCRIPTION
The [current solution](https://github.com/wasm-tool/parcel-plugin-wasm.rs/commit/d5d2fdadcd7622151c192a6badcabeb4db53dba7) does not consider paths with multiple file separators in it (i.e. a subfolder). This pull request changes the behaviour to properly convert all file separators instead of just the first occurrence.